### PR TITLE
fix/project name error

### DIFF
--- a/csharp/initia-proto.csproj
+++ b/csharp/initia-proto.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0;net461;netstandard2.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Version>1.0.0-alpha.1</Version>
-    <Description>protobuf bindings for inita</Description>
+    <Description>protobuf bindings for initia</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <ReleaseVersion>1.0.0-alpha.1</ReleaseVersion>
   </PropertyGroup>

--- a/unity/initia-unity-proto.csproj
+++ b/unity/initia-unity-proto.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0;net461;netstandard2.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Version>1.0.0-alpha.1</Version>
-    <Description>protobuf bindings for inita - unity compatible</Description>
+    <Description>protobuf bindings for initia - unity compatible</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <ReleaseVersion>1.0.0-alpha.1</ReleaseVersion>
   </PropertyGroup>


### PR DESCRIPTION
***Description:***
Corrected a typo in the < Description > line within `initia-unity-proto.csproj`. The word “inita” was changed to “initia” to ensure accurate spelling. This minor fix improves readability and maintains a professional standard for the codebase.

***Changes:***
 • Updated < Description > line in the `initia-unity-proto.csproj`
 file:

<Description>protobuf bindings for `inita` - unity compatible</Description>;



***Testing:***
No functional code changes were made; only the error message text was updated. The change does not affect any logic or functionality, so existing tests (if any) should continue to pass without modification.