### PR TITLE
feat(rust): add miniwasm x/tokenfactory types

### DIFF
--- a/rust/builder/build.rs
+++ b/rust/builder/build.rs
@@ -35,6 +35,7 @@ const ICS_DIR: &str = "../../ics23/proto";
 const SDK_DIR: &str = "../../block-sdk/proto";
 const SLINKY_DIR: &str = "../../slinky/proto";
 const THIRDPARTY_DIR: &str = "../../third_party";
+const MINIWASM_PROTO_DIR: &str = "../../miniwasm/proto";
 
 /// A temporary directory for proto building
 const TMP_BUILD_DIR: &str = "/tmp/tmp-protobuf/";
@@ -86,7 +87,10 @@ fn main() {
     run_rustfmt(&output_dir);
 
     if is_github() {
-        println!("Rebuild protos with proto-build (initia rev: {})", INITIA_REV);
+        println!(
+            "Rebuild protos with proto-build (initia rev: {})",
+            INITIA_REV
+        );
     }
 }
 
@@ -164,12 +168,14 @@ fn compile_initia_protos_and_services(out_dir: &Path) {
         SDK_DIR.to_owned(),
         SLINKY_DIR.to_owned(),
         THIRDPARTY_DIR.to_owned(),
+        MINIWASM_PROTO_DIR.to_owned(),
     ];
 
     // Paths
     let proto_paths = [
         INITIA_DIR.to_owned(),
-        /* 
+        MINIWASM_PROTO_DIR.to_owned(),
+        /*
         format!("{}/proto/initia/distribution", sdk_dir.display()),
         format!("{}/proto/initia/mint", sdk_dir.display()),
         format!("{}/proto/initia/move", sdk_dir.display()),
@@ -212,7 +218,7 @@ fn compile_dependent_protos_and_services(out_dir: &Path) {
     // List available paths for dependencies
     let includes: Vec<PathBuf> = proto_includes_paths.iter().map(PathBuf::from).collect();
 
-        // Paths
+    // Paths
     let proto_paths = [
         COSMOS_DIR.to_owned(),
         COSMOS_PROTO_DIR.to_owned(),
@@ -221,7 +227,7 @@ fn compile_dependent_protos_and_services(out_dir: &Path) {
         SDK_DIR.to_owned(),
         SLINKY_DIR.to_owned(),
         THIRDPARTY_DIR.to_owned(),
-        /* 
+        /*
         format!("{}/proto/confio/auth", thirdparty_dir.display()),
         format!("{}/proto/cosmos/auth", thirdparty_dir.display()),
         format!("{}/proto/cosmos/authz", thirdparty_dir.display()),
@@ -249,7 +255,6 @@ fn compile_dependent_protos_and_services(out_dir: &Path) {
         format!("{}/proto/ibc", thirdparty_dir.display()),
         format!("{}/proto/tendermint", thirdparty_dir.display()),
         */
-
     ];
 
     // List available proto files
@@ -347,7 +352,7 @@ fn copy_and_patch(src: impl AsRef<Path>, dest: impl AsRef<Path>) -> io::Result<(
              #[cfg_attr(docsrs, doc(cfg(feature = \"grpc\")))]",
         ),
     ];
-    
+
     // Skip proto files belonging to `EXCLUDED_PROTO_PACKAGES`
     for package in EXCLUDED_PROTO_PACKAGES {
         if let Some(filename) = src.as_ref().file_name().and_then(OsStr::to_str) {
@@ -400,9 +405,11 @@ fn apply_patches(output_dir: &Path) {
     fs::rename(
         &output_dir.join("initia.r#move.v1.rs"),
         &output_dir.join("initia.move.v1.rs"),
-    ).unwrap();
+    )
+    .unwrap();
     fs::rename(
         &output_dir.join("initia.r#move.module.v1.rs"),
         &output_dir.join("initia.move.module.v1.rs"),
-    ).unwrap();
+    )
+    .unwrap();
 }

--- a/rust/initia-proto/src/lib.rs
+++ b/rust/initia-proto/src/lib.rs
@@ -669,3 +669,11 @@ pub mod capability {
 pub mod cosmos_proto {
     include!("proto/cosmos_proto.rs");
 }
+
+pub mod miniwasm {
+    pub mod tokenfactory {
+        pub mod v1 {
+            include!("proto/miniwasm.tokenfactory.v1.rs");
+        }
+    }
+}

--- a/rust/initia-proto/src/lib.rs
+++ b/rust/initia-proto/src/lib.rs
@@ -13,7 +13,6 @@ pub use prost_types::Any;
 // we use tendermint.*.rs in prost instead of tendermint-rs
 pub use tendermint_proto as tendermint;
 
-
 /// Cosmos protobuf definitions.
 pub mod cosmos {
 
@@ -106,7 +105,6 @@ pub mod cosmos {
             }
         }
 
-
         pub mod tendermint {
             pub mod v1beta1 {
                 include!("proto/cosmos.base.tendermint.v1beta1.rs");
@@ -118,7 +116,7 @@ pub mod cosmos {
         }
     }
 
-        pub mod circuit {
+    pub mod circuit {
         pub mod module {
             pub mod v1 {
                 include!("proto/cosmos.circuit.module.v1.rs");
@@ -351,14 +349,14 @@ pub mod cosmos {
     pub mod store {
         pub mod internal {
             pub mod kv {
-            pub mod v1beta1 {
-                include!("proto/cosmos.store.internal.kv.v1beta1.rs");
+                pub mod v1beta1 {
+                    include!("proto/cosmos.store.internal.kv.v1beta1.rs");
+                }
             }
-        }
         }
 
         pub mod snapshots {
-            pub mod v1{
+            pub mod v1 {
                 include!("proto/cosmos.store.snapshots.v1.rs");
             }
         }
@@ -368,7 +366,6 @@ pub mod cosmos {
                 include!("proto/cosmos.store.streaming.abci.rs");
             }
         }
-
 
         pub mod v1beta1 {
             include!("proto/cosmos.store.v1beta1.rs");
@@ -428,17 +425,6 @@ pub mod ibc {
         pub mod fee {
             pub mod v1 {
                 include!("proto/ibc.applications.fee.v1.rs");
-            }
-        }
-
-        pub mod fetchprice {
-            pub mod module {
-                pub mod v1 {
-                    include!("proto/ibc.applications.fetchprice.module.v1.rs");
-                }
-            }
-            pub mod v1 {
-                include!("proto/ibc.applications.fetchprice.v1.rs");
             }
         }
 
@@ -544,7 +530,7 @@ pub mod ibc {
                 include!("proto/ibc.lightclients.tendermint.v1.rs");
             }
         }
-                pub mod wasm {
+        pub mod wasm {
             pub mod v1 {
                 include!("proto/ibc.lightclients.wasm.v1.rs");
             }
@@ -675,69 +661,11 @@ pub mod sdk {
 }
 
 pub mod capability {
-        pub mod v1 {
-            include!("proto/capability.v1.rs");
-        }
+    pub mod v1 {
+        include!("proto/capability.v1.rs");
+    }
 }
 
 pub mod cosmos_proto {
     include!("proto/cosmos_proto.rs");
-}
-
-pub mod slinky {
-    pub mod abci {
-        pub mod v1 {
-            include!("proto/slinky.abci.v1.rs");
-        }
-    }
-
-    pub mod alerts {
-        pub mod module {
-            pub mod v1 {
-                include!("proto/slinky.alerts.module.v1.rs");
-            }
-        }
-        pub mod v1 {
-            include!("proto/slinky.alerts.v1.rs");
-        }
-    }
-
-    pub mod incentives {
-        pub mod module {
-            pub mod v1 {
-                include!("proto/slinky.incentives.module.v1.rs");
-            }
-        }
-        pub mod v1 {
-            include!("proto/slinky.incentives.v1.rs");
-        }
-    }
-
-    pub mod oracle {
-        pub mod module {
-            pub mod v1 {
-                include!("proto/slinky.oracle.module.v1.rs");
-            }
-        }
-        pub mod v1 {
-            include!("proto/slinky.oracle.v1.rs");
-        }
-    }
-
-    pub mod service {
-        pub mod v1 {
-            include!("proto/slinky.service.v1.rs");
-        }
-    }
-
-    pub mod sla {
-        pub mod module {
-            pub mod v1 {
-                include!("proto/slinky.sla.module.v1.rs");
-            }
-        }
-        pub mod v1 {
-            include!("proto/slinky.sla.v1.rs");
-        }
-    }
 }

--- a/rust/initia-proto/src/type_urls.rs
+++ b/rust/initia-proto/src/type_urls.rs
@@ -4,7 +4,7 @@
 // TODO(tarcieri): leverage first-class support for type URLs in prost?
 // See: https://github.com/tokio-rs/prost/issues/299
 
-use crate::{cosmos, ibc, initia, traits::TypeUrl};
+use crate::{cosmos, ibc, initia, miniwasm, traits::TypeUrl};
 
 impl TypeUrl for cosmos::bank::v1beta1::MsgSend {
     const TYPE_URL: &'static str = "/cosmos.bank.v1beta1.MsgSend";
@@ -13,7 +13,7 @@ impl TypeUrl for cosmos::bank::v1beta1::MsgSend {
 impl TypeUrl for cosmos::bank::v1beta1::MsgMultiSend {
     const TYPE_URL: &'static str = "/cosmos.bank.v1beta1.MsgMultiSend";
 }
- 
+
 impl TypeUrl for cosmos::distribution::v1beta1::MsgSetWithdrawAddress {
     const TYPE_URL: &'static str = "/cosmos.distribution.v1beta1.MsgSetWithdrawAddress";
 }
@@ -82,36 +82,61 @@ impl TypeUrl for ibc::applications::transfer::v1::MsgTransfer {
     const TYPE_URL: &'static str = "/ibc.applications.transfer.v1.MsgTransfer";
 }
 
-impl TypeUrl for initia::mstaking::v1::MsgCreateValidator{
+impl TypeUrl for initia::mstaking::v1::MsgCreateValidator {
     const TYPE_URL: &'static str = "/initia.mstaking.v1.MsgCreateValidator";
 }
 
-impl TypeUrl for initia::mstaking::v1::MsgEditValidator{
+impl TypeUrl for initia::mstaking::v1::MsgEditValidator {
     const TYPE_URL: &'static str = "/initia.mstaking.v1.MsgEditValidator";
 }
 
-impl TypeUrl for initia::mstaking::v1::MsgDelegate{
+impl TypeUrl for initia::mstaking::v1::MsgDelegate {
     const TYPE_URL: &'static str = "/initia.mstaking.v1.MsgDelegate";
 }
 
-impl TypeUrl for initia::mstaking::v1::MsgBeginRedelegate{
+impl TypeUrl for initia::mstaking::v1::MsgBeginRedelegate {
     const TYPE_URL: &'static str = "/initia.mstaking.v1.MsgBeginRedelegate";
 }
 
-impl TypeUrl for initia::mstaking::v1::MsgUndelegate{
+impl TypeUrl for initia::mstaking::v1::MsgUndelegate {
     const TYPE_URL: &'static str = "/initia.mstaking.v1.MsgUndelegate";
 }
 
-impl TypeUrl for initia::r#move::v1::MsgPublish{
+impl TypeUrl for initia::r#move::v1::MsgPublish {
     const TYPE_URL: &'static str = "/initia.move.v1.MsgPublish";
 }
 
-impl TypeUrl for initia::r#move::v1::MsgExecute{
+impl TypeUrl for initia::r#move::v1::MsgExecute {
     const TYPE_URL: &'static str = "/initia.move.v1.MsgExecute";
 }
 
-impl TypeUrl for initia::r#move::v1::MsgScript{
+impl TypeUrl for initia::r#move::v1::MsgScript {
     const TYPE_URL: &'static str = "/initia.move.v1.MsgScript";
 }
 
+impl TypeUrl for miniwasm::tokenfactory::v1::MsgCreateDenom {
+    const TYPE_URL: &'static str = "/miniwasm.tokenfactory.v1.MsgCreateDenom";
+}
+
+impl TypeUrl for miniwasm::tokenfactory::v1::MsgMint {
+    const TYPE_URL: &'static str = "/miniwasm.tokenfactory.v1.MsgMint";
+}
+
+impl TypeUrl for miniwasm::tokenfactory::v1::MsgBurn {
+    const TYPE_URL: &'static str = "/miniwasm.tokenfactory.v1.MsgBurn";
+}
+
+impl TypeUrl for miniwasm::tokenfactory::v1::MsgChangeAdmin {
+    const TYPE_URL: &'static str = "/miniwasm.tokenfactory.v1.MsgChangeAdmin";
+}
+
+impl TypeUrl for miniwasm::tokenfactory::v1::MsgSetBeforeSendHook {
+    const TYPE_URL: &'static str = "/miniwasm.tokenfactory.v1.MsgSetBeforeSendHook";
+}
+
+impl TypeUrl for miniwasm::tokenfactory::v1::MsgSetDenomMetadata {
+    const TYPE_URL: &'static str = "/miniwasm.tokenfactory.v1.MsgSetDenomMetadata";
+}
+
 // no msgs for tendermint
+


### PR DESCRIPTION
This PR updates the `initia-proto` Rust types to include the `x/tokenfactory` types from miniwasm.  
Additionally, it removes the `slinky` modules and `ibc.applications.fetchprice`, as they are not generated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for enhanced token factory operations with new messaging features.
	- Extended proto file inclusion to support additional functionalities.
- **Refactor**
	- Streamlined module organization by removing obsolete components and reorganizing namespaces.
- **Style**
	- Improved formatting and readability across the codebase for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->